### PR TITLE
Allow optionals with none as default

### DIFF
--- a/src/snakemake_argparse_bridge/__init__.py
+++ b/src/snakemake_argparse_bridge/__init__.py
@@ -69,17 +69,17 @@ class SnakemakeArgparseBridge:
 
             # If a type is specified, attempt to cast it
             arg_type = action.type
-            if arg_type is not None:
+            if arg_type is not None and value is not None:
                 value = arg_type(value)
 
             if value is not None:
                 setattr(namespace, arg_name, value)
-            elif action.default is not None:
-                setattr(namespace, arg_name, action.default)
-            elif action.required:
+            elif action.required and value is None:
                 raise ValueError(
                     f"Required argument '{arg_name}' not found in Snakemake context"
                 )
+            else:
+                setattr(namespace, arg_name, action.default)
 
         return namespace
 
@@ -109,7 +109,10 @@ class SnakemakeArgparseBridge:
                 index = int(index_part.rstrip("]"))
                 obj = getattr(obj, attr_name)[index]
             else:
-                obj = getattr(obj, attr)
+                try:
+                    obj = getattr(obj, attr)
+                except AttributeError:
+                    obj = None
         return obj
 
 

--- a/tests/scripts/process_sample.py
+++ b/tests/scripts/process_sample.py
@@ -27,6 +27,8 @@ from snakemake_argparse_bridge import snakemake_compatible
         "threads": "threads",
         "memory": "resources.mem_mb",
         "runtime": "resources.runtime",
+        "subset": "params.subset",
+        "overrides": "params.overrides",
     }
 )
 def main():
@@ -41,6 +43,8 @@ def main():
     parser.add_argument("--threads", type=int, default=1, help="Number of threads")
     parser.add_argument("--memory", type=int, help="Memory in MB")
     parser.add_argument("--runtime", type=int, help="Runtime in minutes")
+    parser.add_argument("--subset", required=False, default="all")
+    parser.add_argument("--overrides", required=False, default=None)
 
     args = parser.parse_args()
 
@@ -53,6 +57,8 @@ def main():
         "threads": args.threads,
         "memory": args.memory,
         "runtime": args.runtime,
+        "subset": args.subset,
+        "overrides": args.overrides or "NOT SPECIFIED",
         "input_file": str(args.input_file),
         "output_file": str(args.output_file),
     }
@@ -85,6 +91,8 @@ def main():
         f.write(f"Threads: {args.threads}\n")
         f.write(f"Memory: {args.memory}MB\n")
         f.write(f"Runtime: {args.runtime}min\n")
+        f.write(f"Subset: {args.subset}")
+        f.write(f"Overrides: {args.overrides}\n")
         f.write(f"Processed Data: {processed_data}\n")
 
     print(f"Successfully processed {args.sample} with {args.method} method")


### PR DESCRIPTION
I hit this issue with a script that had optional arguments that were not needed in the snakemake invocation, which had a two fold issue:

1. When we look for the argument from snakemake if there is nothing from snakemake it was crashing, despite being optional
2. None results were being typed which isn't ideal - I think
3. The ordering of the setting the attribute meant that if a value was None it wasn't actually being set on the args structure, which then causes the script to fail - none is a valid default so we should ensure it is propegated. But worth double checking my change to the logic here in case I'm not aware of some other case.

I updated the testcase script so it fails without this change and passes with it.