### PR TITLE
Work around snakemake module change in 9.17

### DIFF
--- a/src/snakemake_argparse_bridge/__init__.py
+++ b/src/snakemake_argparse_bridge/__init__.py
@@ -3,6 +3,7 @@ A bridge package to make argparse-based scripts work seamlessly with Snakemake.
 """
 
 import argparse
+import sys
 from typing import Dict, Any, Optional, Callable, Union
 
 
@@ -44,11 +45,9 @@ class SnakemakeArgparseBridge:
     def _detect_snakemake_context(self) -> bool:
         """Detect if we're running within a Snakemake script context."""
         try:
-            import snakemake.script
-
-            self._snakemake = snakemake.script.snakemake
-            return True
-        except (ImportError, AttributeError):
+            self._snakemake = sys.modules["__main__"].snakemake
+            return self._snakemake != None
+        except AttributeError:
             return False
 
     def _parse_from_snakemake(self):


### PR DESCRIPTION
This is a fix for #10 

In 9.17 the internal variable used to store snakemake went away:

https://github.com/snakemake/snakemake/compare/v9.16.3...v9.17.2#diff-b400b68fc9448c5998b0a79d12219bb7b09247c3a2ee9631fbfaacbdcdd6bcc4L765

Given there is no official API for third party code to work out if it is in a snakemake environment or not, this PR removes the now broken code with a check for the main namespace, which whilst horrible is AFAICT the only "officially supported" way to tell if you're using snakemake or not.

I manually tested this with 9.17.2 and 9.16.3 (to check for regression) and similar ran the unit tests with both.